### PR TITLE
Add fallback defaults for no config

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A simple Python 3 CLI for searching the [Jisho.org](https://jisho.org/) Japanese
 
 ## Usage
 
-`jisho_cli.py` `[-h] [-m N] [--version]` `<one or more search keywords>`
+`jisho-cli` `[-h] [-m N] [--version]` `<one or more search keywords>`
 
 ### Positional arguments
 - <one or more search keyword(s)>
@@ -24,48 +24,27 @@ A simple Python 3 CLI for searching the [Jisho.org](https://jisho.org/) Japanese
 
 ## Installation
 
-### Package dependencies
-Recommended to be installed via the *requirements.txt* file.
-
-- [appdirs](https://pypi.org/project/appdirs/)
-- [colorama](https://pypi.org/project/colorama/)
-- [Requests](https://pypi.org/project/requests/)
-- [PyYAML](https://pypi.org/project/PyYAML/)
-- [termcolor](https://pypi.org/project/termcolor/)
-
-### Installation example (Linux)
-Optional: use a <a target="_blank" rel="noopener noreferrer" href="https://docs.python.org/3/library/venv.html">virtual environment</a>:
+One-liner install with [pipx](https://github.com/pypa/pipx):
 
 ```bash
-python -m venv venv
-venv/scripts/activate
+pipx install git+https://github.com/vakanen/python-jisho-cli.git
 ```
 
-Installation:
+Creating a config file (optional):
 
 ```bash
-git clone https://github.com/vakanen/python-jisho-cli
-cd python-jisho-cli
+# Linux example
 
-# Move the config file
+# Get the git files
+git clone https://github.com/vakanen/python-jisho-cli
+pushd "./python-jisho-cli/"
+
+# Copy the config file
 mkdir -p ~/.config/jisho_cli && cp ./config.yml "$_"
 
-# Make the script executable
-chmod +x ./jisho_cli.py
-
-# Install requirements
-pip install --user -r requirements.txt
-
-# Run the script
-./jisho_cli.py "Test phrase" # Quotations for multi-words queries
-./jisho_cli.py Test |less # Results piped to less
-```
-
-Optionally, to shorten the invocation:
-
-```bash
-# Alias in .bashrc or similar
-alias jisho_cli=/path/to/python-jisho-cli/jisho_cli.py
+# Remove the git files
+popd
+rm -rf "./python-jisho-cli/"
 ```
 
 ### Config file location

--- a/jisho_cli.py
+++ b/jisho_cli.py
@@ -41,13 +41,42 @@ import yaml
 from colorama import init
 from termcolor import colored, cprint
 
-SCRIPT_VERSION = '0.1.3'
+SCRIPT_VERSION = '0.2.0'
 SCRIPT_NAME = 'jisho_cli'
 
 CFG_PATH = os.path.join(appdirs.user_config_dir(SCRIPT_NAME), 'config.yml')
 
-with open(file=CFG_PATH, mode="r", encoding="utf-8") as f_cfg:
-    CFG = yaml.safe_load(f_cfg)
+# Try to open user-defined preferences
+try:
+    with open(file=CFG_PATH, mode='r', encoding='utf-8') as f_cfg:
+        CFG = yaml.safe_load(f_cfg)
+# But fall back to defaults if user config didn't exist.
+# Hardcoding this instead of reading the repo config, because
+# the user could've installed this package using custom tools
+# where we don't know the location (or even the existence) of config.yml.
+except FileNotFoundError:
+    CFG = yaml.safe_load("""
+        # The Jisho API url to use for lookups
+        # Default value: https://jisho.org/api/v1
+        api_base_url: https://jisho.org/api/v1
+
+        # How many dictionary definitions to return, at most.
+        # Use zero for no limit.
+        # Value has to be zero or a positive integer.
+        # Default value: 3
+        max_results_default: 3
+
+        # For possible values, see: https://pypi.org/project/termcolor/
+        warning_text_color: yellow # Default value: yellow
+        success_text_color: green # Default value: green
+
+        # By default, the script makes sure its name matches
+        # this config file's path, for naming consistency
+        # (eg: "~/.config/jisho-cli/config.yml").
+        # You can ignore this check by changing this value to True.
+        # Default value: False
+        ignore_script_name_mismatch: False
+    """)
 assert CFG is not None
 
 # Initialize Colorama for platform independent terminal colour support.


### PR DESCRIPTION
Add default configuration values for cases where the user runs the script without a config file.

This change makes the existence of the config file within the user's configdir path optional.

Fixes #4 