### PR TITLE
Add useragent to GET header

### DIFF
--- a/jisho_cli.py
+++ b/jisho_cli.py
@@ -22,7 +22,7 @@ import yaml
 from colorama import init
 from termcolor import colored, cprint
 
-SCRIPT_VERSION = '0.4.0'
+SCRIPT_VERSION = '0.5.0'
 SCRIPT_NAME = 'jisho_cli'
 
 CFG_PATH = os.path.join(appdirs.user_config_dir(SCRIPT_NAME), 'config.yml')
@@ -152,8 +152,11 @@ def main():
         Returns a JSON object.
         """
         url = CFG['api_base_url'] + '/search/words?keyword=' + phrase
+        headers = {'user-agent': f'script-{SCRIPT_NAME}/{SCRIPT_VERSION}'}
         try:
-            resp = requests.get(url, **{ 'timeout': None if args.timeout == 0 else args.timeout })
+            resp = requests.get(url,
+                                headers=headers,
+                                **{ 'timeout': None if args.timeout == 0 else args.timeout })
         except Exception as err:
             # --decompound is a special case where we might be doing several API lookups
             # in a row, so on timeout we suggest overriding that timeout limit.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jisho-cli"
-version = "0.4.0"
+version = "0.5.0"
 description = "A simple Python 3 CLI for searching the Jisho.org Japanese language dictionary directly from the terminal."
 authors = ["vakanen <ge260vtan@mozmail.com>"]
 license = "GNU General Public License v3.0"
@@ -8,16 +8,17 @@ license = "GNU General Public License v3.0"
 [tool.poetry.dependencies]
 python = "^3.6"
 appdirs = "~1.4.4"
-certifi = ">=2021.10.8"
+certifi = ">=2024.2.2"
 chardet = "~4.0.0"
 colorama = "~0.4.4"
 idna = "^2.10"
 pykakasi = "2.2.1"
-PyYAML = "~5.4.1"
-requests = "~2.25.1"
+PyYAML = "~6.0.1"
+requests = "~2.27.1"
 termcolor = "~1.1.0"
-urllib3 = "~1.26.6"
+urllib3 = "~1.26.18"
 wincertstore = {version = "^0.2", markers = "sys_platform == 'win32' and python_version < '2.7.9'"}
+wrapt = "~1.16.0"
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.14.5"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@ chardet==4.0.0
 colorama==0.4.4
 idna==2.10
 pykakasi==2.2.1
-PyYAML==5.4.1
-requests==2.25.1
+PyYAML==6.0.1
+requests~=2.27.1
 termcolor==1.1.0
-urllib3==1.26.6
+urllib3~=1.26.6
 wincertstore==0.2; platform_system == 'Windows' and python_version < '2.7.9' 


### PR DESCRIPTION
Add useragent to HTTP GET headers to avoid 403 responses from the API.

Also update requirements to fix a PyYAML version incompatibility with Cython.